### PR TITLE
Fix: Infinite loading due to view private metadata size limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ You need the following prerequisites:
 For starters clone the git repository into a new directory called `mm_app`:
 
 ```shell
-git clone https://github.com/schultek/mm_app mm_app
+git clone https://github.com/manageandmore/my_mm mm_app
 cd mm_app
 ```
 

--- a/src/features/wishlist/events/open_wishlist.ts
+++ b/src/features/wishlist/events/open_wishlist.ts
@@ -24,7 +24,7 @@ slack.action(
 
     console.time("Wishlist Query");
 
-    var items = await queryWishlistItems(payload.user.id);
+    const items = await queryWishlistItems(payload.user.id);
 
     console.timeEnd("Wishlist Query");
 

--- a/src/features/wishlist/events/vote_suggestion.ts
+++ b/src/features/wishlist/events/vote_suggestion.ts
@@ -3,7 +3,7 @@ import { notion } from "../../../notion";
 import { slack } from "../../../slack";
 import { getScholarIdFromUserId } from "../../common/id_utils";
 import { getWishlistModal } from "../views/wishlist_modal";
-import { WishlistItem } from "../data/query_items";
+import {queryWishlistItems, WishlistItem} from "../data/query_items";
 import { getVoterById } from "../data/get_voter";
 
 export const voteWishlistItemAction = "vote_wishlist_item";
@@ -22,10 +22,11 @@ slack.action(
     const currentUserId = payload.user.id;
     const action = payload.actions[0] as ButtonAction;
 
-    var view = payload.view!;
-    // Retrieve the current items from the json payload of the view.
-    // This is faster than re-querying the data from the database.
-    const items = JSON.parse(view.private_metadata) as WishlistItem[];
+    const view = payload.view!;
+
+    // Query wishlist items from Notion.
+    // We re-fetch because private metadata of the view cannot hold JSON objects larger than 3k characters.
+    const items = await queryWishlistItems(payload.user.id) as WishlistItem[];
 
     for (var item of items) {
       // Find the item that the user voted on.
@@ -53,9 +54,10 @@ slack.action(
     const voted = action.value == "true";
 
     const view = payload.view!;
-    // Retrieve the current items from the json payload of the view.
-    // This is faster than re-querying the data from the database.
-    const items = JSON.parse(view.private_metadata) as WishlistItem[];
+
+    // Query wishlist items from Notion.
+    // We re-fetch because private metadata of the view cannot hold JSON objects larger than 3k characters.
+    const items = await queryWishlistItems(payload.user.id) as WishlistItem[];
 
     // Find the item that the user voted on.
     let selectedItem: WishlistItem | null = null;

--- a/src/features/wishlist/views/wishlist_modal.ts
+++ b/src/features/wishlist/views/wishlist_modal.ts
@@ -86,7 +86,6 @@ export function getWishlistModal(options: WishlistOptions): ModalView {
       emoji: true,
     },
     blocks: blocks,
-    private_metadata: JSON.stringify(options.items ?? []),
   };
 }
 


### PR DESCRIPTION
Currently the wishlist is stuck in a loading screen when opening it. This is due to an error happening during the processing of data from Notion. For caching purposes, the fetched data was previously stored as a JSON object in the `private_metadata` property of the view. This property can only hold information of up to 3000 characters. The size of the wishlist as a JSON object greatly exceeds the 3000 character limit, therefore it cannot be used reliably and we instead need to fetch the data again.
The performance impact is quite small and a loading indicator indicates that action is happening.