### PR TITLE
add inbox functionality via app tag + "-add to inbox" flag to any private channel

### DIFF
--- a/src/features/assistant/_FEATURE.md
+++ b/src/features/assistant/_FEATURE.md
@@ -10,6 +10,7 @@ This feature provides an ai assistant for scholars to ask questions about inform
 - A vector database to store data from notion and slack.
   - For slack, a few selected channels are automatically indexed, where each new message is added to the vector db.
   - For notion, some selected pages and databased are indexed. This is controlled by the "Assistant Index" notion database. Pages are split in chunks, Databases are added by each row.
+- The assistant can be called upon to answer any message by tagging @MyMM and adding an "-AI" (case insensitive)
 
 ## Structure
 

--- a/src/features/assistant/events/app_mention.ts
+++ b/src/features/assistant/events/app_mention.ts
@@ -34,8 +34,9 @@ anyMessage(async (request) => {
  */
 slack.event("app_mention", async (request) => {
   const payload = request.payload;
-
-  await triggerAssistant(payload, request.context.botUserId);
+  if (payload.text.toLowerCase().includes("-ai")) {
+    await triggerAssistant(payload, request.context.botUserId);
+  }
 });
 
 /**

--- a/src/features/inbox/_FEATURE.md
+++ b/src/features/inbox/_FEATURE.md
@@ -8,6 +8,7 @@ This feature provides the user with a list of messages and notifications that ha
 
 - A cron job will check everyday at 11:30 am for overdue reminders and send a message to the user to remind him to anwer
 - https://calndr.link/api-docs used for creation of google calendar event
+- The assistant can be called upon to answer any message by tagging @MyMM and adding an "-add to inbox" (case insensitive)
 
 ## Structure
 

--- a/src/features/inbox/events/add_to_inbox.ts
+++ b/src/features/inbox/events/add_to_inbox.ts
@@ -26,11 +26,14 @@ anyMessage(async (request) => {
   if (!isIndexed) {
     return;
   }
+  await responseEmphemeral(payload.channel, payload.user, payload.ts);
+});
 
+async function responseEmphemeral(channel: string, user: string, ts: string) {
   // Send an ephemeral message with an interactive button
   await slack.client.chat.postEphemeral({
-    channel: payload.channel,
-    user: payload.user,
+    channel: channel,
+    user: user,
     text: "📬 Would you like to add this message to the *Inbox* of all users in this channel?", // Fallback text for notifications
     blocks: [
       {
@@ -72,8 +75,8 @@ anyMessage(async (request) => {
               emoji: true,
             },
             value: JSON.stringify({
-              channelId: payload.channel,
-              messageTs: payload.ts,
+              channelId: channel,
+              messageTs: ts,
             }),
             action_id: newMessageAction,
           },
@@ -81,4 +84,33 @@ anyMessage(async (request) => {
       },
     ],
   });
+}
+
+/**
+ * Handle the app_mention event by prompting chatgpt to respond to the users message.
+ *
+ * The event fires each time a user mentions the slack app in a message.
+ * The handler will prompt chatgpt with the users message and post its response as a new message in the same channel.
+ */
+
+slack.event("app_mention", async (request) => {
+  const payload = request.payload;
+  console.log("app_mention", payload);
+
+  // Guard for inbox add
+  if (payload.text.toLowerCase().includes("-add to inbox")) {
+    console.log("add to inbox");
+    if (payload.blocks) {
+      for (const blockType of payload.blocks) {
+        if (blockType.type !== "rich_text") {
+          console.log("block type not rich text");
+          return;
+        }
+      }
+      // Check that message has user
+      if (payload.user) {
+        await responseEmphemeral(payload.channel, payload.user, payload.ts);
+      }
+    }
+  }
 });

--- a/src/features/inbox/events/create_new_message.ts
+++ b/src/features/inbox/events/create_new_message.ts
@@ -44,6 +44,14 @@ slack.action(newMessageAction, async (request) => {
     return;
   }
 
+  // Get bot user id
+  const botUserId = (await slack.client.auth.test()).user_id;
+  // remove app mention and command from message
+  message = message
+    .replace(`<@${botUserId}>`, "")
+    .replace(/-add to inbox/, "")
+    .replace(/-Add to inbox/, "");
+
   if (message.length > 200) {
     message = message.substring(0, 197) + "...";
   }

--- a/src/features/inbox/views/outbox_modal.ts
+++ b/src/features/inbox/views/outbox_modal.ts
@@ -81,7 +81,7 @@ export function getOutboxModal(
                     type: "plain_text",
                     text: "No",
                   },
-                }
+                },
               },
             },
           ]
@@ -122,7 +122,7 @@ export function getOutboxModal(
             {
               type: "mrkdwn",
               text: `Responses: ${Object.keys(entry.resolutions).length} / ${
-                entry.recipientIds.length
+                entry.recipientIds.length - 1
               }`,
             },
           ],


### PR DESCRIPTION
- When the app is mentioned combined with an -add to inbox flag the empheral message asking to add the tagged message to the inbox will appear. This way also private channels can use the inbox feature. However, for private channels, the app needs to be added to the channel within Slack for it to work.
- App mention +"-ai" now makes the assistant respond to a given tagged message. 
- Fix for responses list such that the app isn't counted as possible responder anymore -> -1 possible responses

