### PR TITLE
Improve: Add help buttons to home and message creation

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,4 +22,4 @@ export const indexedChannels = ["general", "active"];
 
 /** Bot will ask senders in these channels of they want to add the sent
  * message to all recipients' inboxes */
-export const inboxableChannels = ["general", "active", "niclas-test"];
+export const inboxableChannels = ["general", "active"];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,9 @@ export const currentUrl = process.env.VERCEL_URL;
 /** Prefix for all cache keys. Used to avoid clashes between environments. */
 export const cachePrefix = process.env.CACHE_PREFIX;
 
-
 /** List of automatically indexed channels for the ai assistant. */
 export const indexedChannels = ["general", "active"];
+
+/** Bot will ask senders in these channels of they want to add the sent
+ * message to all recipients' inboxes */
+export const inboxableChannels = ["general", "active", "niclas-test"];

--- a/src/features/home/views/help_section.ts
+++ b/src/features/home/views/help_section.ts
@@ -33,6 +33,6 @@ export function getOpenHelpButton(): Button {
             text: "🤔 Open Help Docs",
             emoji: true,
         },
-        url: "https://www.notion.so/manageandmore/My-MM-Slack-App-10c02ddfbf4e80da95dac9b29543acfa?pvs=4#10e02ddfbf4e801bb6d3e406931587d2",
+        url: "https://www.notion.so/manageandmore/My-MM-Slack-App-10c02ddfbf4e80da95dac9b29543acfa",
     };
 }

--- a/src/features/home/views/help_section.ts
+++ b/src/features/home/views/help_section.ts
@@ -1,0 +1,38 @@
+import { AnyHomeTabBlock, Button } from "slack-edge";
+
+export function getHelpSection(): AnyHomeTabBlock[] {
+    return [
+        {
+            type: "header",
+            text: {
+                type: "plain_text",
+                text: "Help",
+            }
+        },
+        {
+            type: "context",
+            elements: [{
+                type: "mrkdwn",
+                text: "If you need help using MyMM, please refer to the MyMM documentation on Notion or contact a member of IP Infrastructure",
+            }]
+        },
+        {
+            type: "actions",
+            elements: [
+                getOpenHelpButton(),
+            ],
+        },
+    ]
+}
+
+export function getOpenHelpButton(): Button {
+    return {
+        type: "button",
+        text: {
+            type: "plain_text",
+            text: "🤔Open Help Docs",
+            emoji: true,
+        },
+        url: "https://www.notion.so/manageandmore/My-MM-Slack-App-10c02ddfbf4e80da95dac9b29543acfa?pvs=4#10e02ddfbf4e801bb6d3e406931587d2",
+    };
+}

--- a/src/features/home/views/help_section.ts
+++ b/src/features/home/views/help_section.ts
@@ -30,7 +30,7 @@ export function getOpenHelpButton(): Button {
         type: "button",
         text: {
             type: "plain_text",
-            text: "🤔Open Help Docs",
+            text: "🤔 Open Help Docs",
             emoji: true,
         },
         url: "https://www.notion.so/manageandmore/My-MM-Slack-App-10c02ddfbf4e80da95dac9b29543acfa?pvs=4#10e02ddfbf4e801bb6d3e406931587d2",

--- a/src/features/home/views/help_section.ts
+++ b/src/features/home/views/help_section.ts
@@ -13,7 +13,7 @@ export function getHelpSection(): AnyHomeTabBlock[] {
             type: "context",
             elements: [{
                 type: "mrkdwn",
-                text: "If you need help using MyMM, please refer to the MyMM documentation on Notion or contact a member of IP Infrastructure",
+                text: "If you need help using MyMM, please refer to the MyMM documentation on Notion or contact a member of Area Infrastructure",
             }]
         },
         {

--- a/src/features/home/views/home.ts
+++ b/src/features/home/views/home.ts
@@ -11,6 +11,7 @@ import { getAdminSection } from "../admin";
 import { ProfileOptions, getProfileSection } from "./profile_section";
 import { getInboxSection, getOutboxSection } from "../../inbox/views/inbox_section";
 import { ReceivedInboxEntry } from "../../inbox/data";
+import { getHelpSection } from "./help_section";
 
 /** Interface for the data used to hydrate the home view. */
 export type HomeOptions = ProfileOptions & {
@@ -71,6 +72,10 @@ export async function getHomeView(
         type: "divider",
       },
       ...getWishlistSection(),
+      {
+        type: "divider",
+      },
+      ...getHelpSection(),
       {
         type: "divider",
       },

--- a/src/features/inbox/events/add_to_inbox.ts
+++ b/src/features/inbox/events/add_to_inbox.ts
@@ -1,4 +1,4 @@
-import { indexedChannels } from "../../../constants";
+import { inboxableChannels } from "../../../constants";
 import { anyMessage, getPublicChannels, slack } from "../../../slack";
 import { newMessageAction } from "./create_new_message";
 
@@ -22,7 +22,7 @@ anyMessage(async (request) => {
   if (channelName == null) {
     return;
   }
-  const isIndexed = indexedChannels.includes(channelName);
+  const isIndexed = inboxableChannels.includes(channelName);
   if (!isIndexed) {
     return;
   }

--- a/src/features/inbox/views/new_message_modal.ts
+++ b/src/features/inbox/views/new_message_modal.ts
@@ -29,7 +29,6 @@ export async function getNewMessageModal(
       text: {
         type: "mrkdwn",
         text: `*Calendar Event URL:* <${calendarEventUrl}|Google calendar link>`,
-        //text: `*Calendar Event URL:* ${calendarEventUrl}`,
       },
     };
   } else {
@@ -43,12 +42,11 @@ export async function getNewMessageModal(
         type: "button",
         text: {
           type: "plain_text",
-          text: "Add calendar url",
+          text: "Add Calendar URL",
           emoji: true,
         },
         action_id: addCalendarEntryAction,
         value: JSON.stringify({ channelId, messageTs, description, updateUrl }),
-
         //open calendar entry modal + transfer all arguments needed for new message modal which need to be passed through
       },
     };
@@ -86,6 +84,23 @@ export async function getNewMessageModal(
             text: "Write a short subject text for this inbox message including things like a summary, who it is relevant for and how they should respond. Additionally recipients will always see the original message.",
           },
         ],
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "See this doc for a short introduction on this feature: ",
+        },
+        accessory: {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "Inbox & Outbox",
+            emoji: true,
+          },
+          style: "primary",
+          url: "https://www.notion.so/manageandmore/My-MM-Slack-App-10c02ddfbf4e80da95dac9b29543acfa?pvs=4#10e02ddfbf4e801bb6d3e406931587d2",
+        }
       },
       {
         type: "divider",


### PR DESCRIPTION
This PR improves the home view and inbox message creation views by adding two help buttons that link to the general Notion pages:

**Home Screen:**
<img width="873" alt="Screenshot 2024-11-12 at 15 52 31" src="https://github.com/user-attachments/assets/bf320e42-ad6c-4699-97fa-694dd6a3c78c">

**Inbox Modal**
<img width="520" alt="Screenshot 2024-11-12 at 15 53 18" src="https://github.com/user-attachments/assets/10388ca9-c5a9-48c0-9ae6-6e7404283480">
